### PR TITLE
Avoid catching callback errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,11 +94,12 @@ function migrate(databaseClient, migrationsDir, cb) {
       }, Promise.resolve())
 
     promise
-      .then(cb)
-      .catch(() => {
+      .catch(err => {
+        console.log(err)
         log('error', 'One or more migrations failed to apply')
         process.exit()
       })
+      .then(cb)
   })
 }
 


### PR DESCRIPTION
I reversed the then and catch when calling the client callback so that an error in that callback isn't misinterpreted as an error from a migration.